### PR TITLE
Readers: Standardize column headers in HPCToolkit and OTF2 Readers

### DIFF
--- a/pipit/readers/hpctoolkit_reader.py
+++ b/pipit/readers/hpctoolkit_reader.py
@@ -238,7 +238,7 @@ class HPCToolkitReader:
 
                 # checking to see if the last event wasn't the same
                 # if it was then we skip it, as to not have multiple sets of
-                # open/close events for a function that it's still ino
+                # open/close events for a function that it's still in
                 if last_id != calling_context_id:
 
                     # updating the trace_db

--- a/pipit/readers/hpctoolkit_reader.py
+++ b/pipit/readers/hpctoolkit_reader.py
@@ -180,12 +180,13 @@ class HPCToolkitReader:
         # print("hdr_size: ", hdr_size)
 
         data = {
-            "Function Name": [],
+            "Timestamp (ns)": [],
             "Event Type": [],
-            "Time": [],
-            "Process": [],
-            "Graph_Node": [],
-            "Level": [],
+            "Name": [],
+            "Thread ID": [],
+            "Process ID": [],
+            "Cluster Node": [],
+            "CCT Node": [],
         }
         min_max_time = experiment_reader.get_min_max_time()
 
@@ -249,7 +250,7 @@ class HPCToolkitReader:
                     intersect_level = -1
                     intersect_node = node.get_intersection(last_node)
                     # this is the highest node that last_node and node have in
-                    # common we want to close every enter time event higher
+                    # common we want to close every entry time event higher
                     # than than interest node, because those functions have
                     # exited
 
@@ -259,29 +260,31 @@ class HPCToolkitReader:
                         close_node is not None
                         and close_node.get_level() > intersect_level
                     ):
-                        data["Function Name"].append(close_node.name)
+                        data["Name"].append(close_node.name)
                         data["Event Type"].append("Exit")
-                        data["Time"].append(timestamp)
-                        data["Process"].append(proc_num)
-                        data["Graph_Node"].append(close_node)
-                        data["Level"].append(close_node.get_level())
+                        data["Timestamp (ns)"].append(timestamp)
+                        data["Process ID"].append(proc_num[1][1])
+                        data["Thread ID"].append(proc_num[2][1])
+                        data["Cluster Node"].append(proc_num[0][1])
+                        data["CCT Node"].append(close_node)
                         close_node = close_node.parent
 
                     # creating new rows for the new functions entered
-                    enter_list = node.get_node_list(intersect_level)
+                    entry_list = node.get_node_list(intersect_level)
                     # the list of nodes higher than interesect_level
                     # (the level of interesect_node)
 
                     # all of the nodes in this list have entered into the
                     # function since the last poll so we want to create entries
-                    # in the data for the Enter event
-                    for enter_node in enter_list[::-1]:
-                        data["Function Name"].append(enter_node.name)
-                        data["Event Type"].append("Enter")
-                        data["Time"].append(timestamp)
-                        data["Process"].append(proc_num)
-                        data["Graph_Node"].append(enter_node)
-                        data["Level"].append(enter_node.get_level())
+                    # in the data for the Entry event
+                    for entry_node in entry_list[::-1]:
+                        data["Name"].append(entry_node.name)
+                        data["Event Type"].append("Entry")
+                        data["Timestamp (ns)"].append(timestamp)
+                        data["Process ID"].append(proc_num[1][1])
+                        data["Thread ID"].append(proc_num[2][1])
+                        data["Cluster Node"].append(proc_num[0][1])
+                        data["CCT Node"].append(entry_node)
                     last_node = node
 
                 last_id = calling_context_id  # updating last_id
@@ -289,22 +292,51 @@ class HPCToolkitReader:
             # adding last data for trace df
             close_node = last_node
 
-            # after reading through all the trace lines, some Enter events will
+            # after reading through all the trace lines, some Entry events will
             # not have matching Exit events, as the functions were still
             # running in the last poll.  Here we are adding Exit events to all
-            # of the remaining unmatched Enter events
+            # of the remaining unmatched Entry events
             while close_node is not None:
-                data["Function Name"].append(close_node.name)
+                data["Name"].append(close_node.name)
                 data["Event Type"].append("Exit")
-                data["Time"].append(min_max_time[1] - min_max_time[0])
-                data["Process"].append(proc_num)
-                data["Graph_Node"].append(close_node)
-                data["Level"].append(close_node.get_level())
+                data["Timestamp (ns)"].append(min_max_time[1] - min_max_time[0])
+                data["Process ID"].append(proc_num[1][1])
+                data["Thread ID"].append(proc_num[2][1])
+                data["Cluster Node"].append(proc_num[0][1])
+                data["CCT Node"].append(close_node)
                 close_node = close_node.parent
 
         trace_df = pd.DataFrame(data)
+
         trace_df.sort_values(
-            by="Time", axis=0, ascending=True, inplace=True, ignore_index=True
+            by="Timestamp (ns)", axis=0, ascending=True, inplace=True, ignore_index=True
         )
+
+        trace_df = trace_df.astype(
+            {
+                "Event Type": "category",
+                "Name": "category",
+                "Thread ID": "category",
+                "Process ID": "category",
+                "Cluster Node": "category",
+            }
+        )
+
+        # removing unnecessary columns
+        num_process_ids, num_thread_ids = len(set(trace_df["Process ID"])), len(
+            set(trace_df["Thread ID"])
+        )
+
+        if num_process_ids > 1:
+            if num_thread_ids == 1:
+                # remove thread id column for multi-process, single-threaded trace
+                trace_df.drop(columns="Thread ID", inplace=True)
+        else:
+            # remove process id column for single-process trace
+            trace_df.drop(columns="Process ID", inplace=True)
+            if num_thread_ids == 1:
+                # remove thread id column for single-process, single-threaded trace
+                trace_df.drop(columns="Thread ID", inplace=True)
+
         self.trace_df = trace_df
         return pipit.trace.Trace(None, trace_df)

--- a/pipit/readers/otf2_reader.py
+++ b/pipit/readers/otf2_reader.py
@@ -105,9 +105,9 @@ class OTF2Reader:
             }
         elif isinstance(data, tuple):
             """
-            There is a definition called CartTopology which has a field called
-            dimensions that is a tuple of two other definitions called
-            CartDimensions, showing why this nested structure is needed
+            Example: There is a definition called CartTopology which has a
+            field called dimensions that is a tuple of two other definitions
+            called CartDimensions, showing why this nested structure is needed
             """
             return tuple([self.handle_data(data_element) for data_element in data])
         elif isinstance(data, set):
@@ -190,10 +190,15 @@ class OTF2Reader:
                 # location could be thread, process, accelerator stream, etc
                 loc, event = loc_event[0], loc_event[1]
 
-                # information about the location
-                # that the event occurred on
-                thread_ids.append(loc._ref)
-                process_ids.append(loc.group._ref)
+                """
+                information about the location that the event occurred on
+
+                TO DO:
+                need to add support for accelerator and metric locations
+                """
+                if str(loc.type)[13:] == "CPU_THREAD":
+                    thread_ids.append(loc._ref)
+                    process_ids.append(loc.group._ref)
 
                 # type of event - entry, exit, or other types
                 # note: otf2 uses enter/leave but pipit uses entry/exit

--- a/pipit/readers/otf2_reader.py
+++ b/pipit/readers/otf2_reader.py
@@ -221,11 +221,11 @@ class OTF2Reader:
                             # and ignores time so there isn't a duplicate time
                             if value is not None and key != "time":
 
-                                # uses field_to_val to convert all data types appropriately
+                                # uses field_to_val to convert all data types
                                 # and ensure that there are no pickling errors
-                                attributes_dict[self.field_to_val(key)] = self.handle_data(
-                                    value
-                                )
+                                attributes_dict[
+                                    self.field_to_val(key)
+                                ] = self.handle_data(value)
                         event_attributes.append(attributes_dict)
                     else:
                         # nan attributes for leave rows

--- a/pipit/readers/otf2_reader.py
+++ b/pipit/readers/otf2_reader.py
@@ -322,7 +322,7 @@ class OTF2Reader:
 
         # parallelizes the reading of events
         # using the multiprocessing library
-        pool_size = mp.cpu_count
+        pool_size = mp.cpu_count()
         pool = mp.Pool(pool_size)
 
         # confusing, but at this moment in time events_dict is actually a

--- a/pipit/readers/otf2_reader.py
+++ b/pipit/readers/otf2_reader.py
@@ -13,15 +13,9 @@ import pipit.trace
 class OTF2Reader:
     """Reader for OTF2 trace files"""
 
-    def __init__(self, dir_name, num_parallel=None):
+    def __init__(self, dir_name):
         self.dir_name = dir_name  # directory of otf2 file being read
         self.file_name = self.dir_name + "/traces.otf2"
-
-        num_cpus = mp.cpu_count()
-        if num_parallel is None or num_parallel < 1 or num_parallel > num_cpus:
-            self.num_parallel = math.floor(num_cpus * 0.75)
-        else:
-            self.num_parallel = num_parallel
 
     def field_to_val(self, field):
         """
@@ -328,7 +322,8 @@ class OTF2Reader:
 
         # parallelizes the reading of events
         # using the multiprocessing library
-        pool_size, pool = self.num_parallel, mp.Pool(self.num_parallel)
+        pool_size = mp.cpu_count
+        pool = mp.Pool(pool_size)
 
         # confusing, but at this moment in time events_dict is actually a
         # list of dicts that will be merged into one dictionary after this

--- a/pipit/readers/otf2_reader.py
+++ b/pipit/readers/otf2_reader.py
@@ -163,11 +163,9 @@ class OTF2Reader:
             # columns of the DataFrame
             timestamps, event_types, event_attributes, names = [], [], [], []
 
-            """
-            Note:
-            1. The below lists are for storing logical ids.
-            2. Support for GPU events has to be added and unified across readers.
-            """
+            # Note:
+            # 1. The below lists are for storing logical ids.
+            # 2. Support for GPU events has to be added and unified across readers.
             process_ids, thread_ids = [], []
 
             # selects a subset of all trace locations to
@@ -184,12 +182,10 @@ class OTF2Reader:
                 # location could be thread, process, etc
                 loc, event = loc_event[0], loc_event[1]
 
-                """
-                information about the location that the event occurred on
+                # information about the location that the event occurred on
 
-                TO DO:
-                need to add support for accelerator and metric locations
-                """
+                # TO DO:
+                # need to add support for accelerator and metric locations
                 if str(loc.type)[13:] == "CPU_THREAD":
                     thread_ids.append(loc._ref)
                     process_ids.append(loc.group._ref)

--- a/pipit/trace.py
+++ b/pipit/trace.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: MIT
 
+import numpy as np
+
 
 class Trace:
     """A trace dataset is read into an object of this type, which includes one
@@ -29,3 +31,77 @@ class Trace:
         from .readers.hpctoolkit_reader import HPCToolkitReader
 
         return HPCToolkitReader(dirname).read()
+
+    def comm_matrix(self, comm_type="bytes"):
+        """
+        Communication Matrix for Peer-to-Peer (P2P) MPI messages
+
+        Arguments:
+
+        1) comm_type -
+        string to choose whether the communication volume should be measured
+        by bytes transferred between two processes or the number of messages
+        sent (two choices - "bytes" or "counts")
+
+        Returns:
+        A 2D Numpy Array that represents the communication matrix for all P2P
+        messages of the given trace
+
+        Note:
+        The first dimension of the returned 2d array
+        is senders and the second dimension is receivers
+        ex) comm_matrix[sender_rank][receiver_rank]
+        """
+
+        # get the list of ranks/process ids
+        # (mpi messages are sent between processes)
+        ranks = set(
+            self.events.loc[self.events["Location Group Type"] == "PROCESS"][
+                "Location Group ID"
+            ]
+        )
+
+        # create a 2d numpy array that will be returned
+        # at the end of the function
+        communication_matrix = np.zeros(shape=(len(ranks), len(ranks)))
+
+        # filter the dataframe by MPI Send and Isend events
+        sender_dataframe = self.events.loc[
+            self.events["Event Type"].isin(["MpiSend", "MpiIsend"]),
+            ["Location Group ID", "Attributes"],
+        ]
+
+        # get the mpi ranks of all the sender processes
+        sender_ranks = sender_dataframe["Location Group ID"].to_list()
+
+        # get the corresponding mpi ranks of the receivers
+        receiver_ranks = (
+            sender_dataframe["Attributes"]
+            .apply(lambda attrDict: attrDict["receiver"])
+            .to_list()
+        )
+
+        # number of bytes communicated
+        if comm_type == "bytes":
+            # (1 communication is a single row in the sender dataframe)
+            message_volumes = (
+                sender_dataframe["Attributes"]
+                .apply(lambda attrDict: attrDict["msg_length"])
+                .to_list()
+            )
+        elif comm_type == "counts":
+            # 1 message between the pairs of processes
+            # for each row in the sender dataframe
+            message_volumes = np.full(len(sender_dataframe), 1)
+
+        for i in range(len(sender_ranks)):
+            """
+            loops through all the communication events and adds the
+            message volumes to the corresponding entry of the 2d array
+            using the sender and receiver ranks
+            """
+            communication_matrix[sender_ranks[i], receiver_ranks[i]] += message_volumes[
+                i
+            ]
+
+        return communication_matrix

--- a/pipit/trace.py
+++ b/pipit/trace.py
@@ -17,12 +17,12 @@ class Trace:
         self.events = events
 
     @staticmethod
-    def from_otf2(dirname, num_parallel=None):
+    def from_otf2(dirname):
         """Read an OTF2 trace into a new Trace object."""
         # import this lazily to avoid circular dependencies
         from .readers.otf2_reader import OTF2Reader
 
-        return OTF2Reader(dirname, num_parallel).read()
+        return OTF2Reader(dirname).read()
 
     @staticmethod
     def from_hpctoolkit(dirname):

--- a/pipit/trace.py
+++ b/pipit/trace.py
@@ -17,12 +17,12 @@ class Trace:
         self.events = events
 
     @staticmethod
-    def from_otf2(dirname):
+    def from_otf2(dirname, num_parallel=None):
         """Read an OTF2 trace into a new Trace object."""
         # import this lazily to avoid circular dependencies
         from .readers.otf2_reader import OTF2Reader
 
-        return OTF2Reader(dirname).read()
+        return OTF2Reader(dirname, num_parallel).read()
 
     @staticmethod
     def from_hpctoolkit(dirname):


### PR DESCRIPTION
- rename columns
- drop process/thread columns if single-process/single-threaded respectively