### PR TITLE
OTF2 Reader: Performance Improvements

### DIFF
--- a/pipit/readers/otf2_reader.py
+++ b/pipit/readers/otf2_reader.py
@@ -13,7 +13,7 @@ import pipit.trace
 class OTF2Reader:
     """Reader for OTF2 trace files"""
 
-    def __init__(self, dir_name, num_parallel = None):
+    def __init__(self, dir_name, num_parallel=None):
         self.dir_name = dir_name  # directory of otf2 file being read
         self.file_name = self.dir_name + "/traces.otf2"
 

--- a/pipit/readers/otf2_reader.py
+++ b/pipit/readers/otf2_reader.py
@@ -317,31 +317,18 @@ class OTF2Reader:
 
         # parallelizes the reading of events
         # using the multiprocessing library
-<<<<<<< HEAD
-        pool_size = mp.cpu_count()
-        pool = mp.Pool(pool_size)
-=======
         pool_size, pool = self.num_parallel, mp.Pool(self.num_parallel)
->>>>>>> 327c13d (feature: give optional argument for number of cores to parallelize reader with)
 
-        # confusing, but at this moment in time events_dict is actually a
-        # list of dicts that will be merged into one dictionary after this
-        events_dict = pool.map(
+        # list of dataframes returned by the processes pool
+        events_dataframes = pool.map(
             self.events_reader, [(rank, pool_size) for rank in range(pool_size)]
         )
 
         pool.close()
 
-        # combines the dictionaries returned from each
-        # process to generate a full trace
-        for i in range(len(events_dict) - 1):
-            for key, value in events_dict[0].items():
-                value.extend(events_dict[1][key])
-            del events_dict[1]
-        events_dict = events_dict[0]
-
-        # returns the events as a DataFrame
-        events_dataframe = pd.DataFrame(events_dict)
+        # merges the dataframe into one events dataframe
+        events_dataframe = pd.concat(events_dataframes)
+        del events_dataframes
 
         # accessing the clock properties of the trace using the definitions
         clock_properties = self.definitions.loc[

--- a/pipit/readers/otf2_reader.py
+++ b/pipit/readers/otf2_reader.py
@@ -236,31 +236,17 @@ class OTF2Reader:
 
             trace.close()  # close event files
 
-<<<<<<< HEAD
         # returns dictionary with all events and their fields
-        return {
-            "Timestamp (ns)": timestamps,
-            "Event Type": event_types,
-            "Name": names,
-            "Thread": thread_ids,
-            "Process": process_ids,
-            "Attributes": event_attributes,
-        }
-=======
-        # returns dataframe with all events and their fields
         return pd.DataFrame(
             {
-                "Event Type": event_types,
                 "Timestamp (ns)": timestamps,
+                "Event Type": event_types,
                 "Name": names,
-                "Location ID": locs,
-                "Location Type": loc_types,
-                "Location Group ID": loc_groups,
-                "Location Group Type": loc_group_types,
+                "Thread": thread_ids,
+                "Process": process_ids,
                 "Attributes": event_attributes,
             }
         )
->>>>>>> d964cef9f02dcb01f5cd14dbaa55e6aea6fd5e2f
 
     def read_definitions(self, trace):
         """

--- a/pipit/readers/otf2_reader.py
+++ b/pipit/readers/otf2_reader.py
@@ -13,9 +13,15 @@ import pipit.trace
 class OTF2Reader:
     """Reader for OTF2 trace files"""
 
-    def __init__(self, dir_name):
+    def __init__(self, dir_name, num_parallel = None):
         self.dir_name = dir_name  # directory of otf2 file being read
         self.file_name = self.dir_name + "/traces.otf2"
+
+        num_cpus = mp.cpu_count()
+        if num_parallel is None or num_parallel < 1 or num_parallel > num_cpus:
+            self.num_parallel = math.floor(num_cpus * 0.75)
+        else:
+            self.num_parallel = num_parallel
 
     def field_to_val(self, field):
         """
@@ -307,7 +313,7 @@ class OTF2Reader:
 
         # parallelizes the reading of events
         # using the multiprocessing library
-        pool_size, pool = mp.cpu_count(), mp.Pool()
+        pool_size, pool = self.num_parallel, mp.Pool(self.num_parallel)
 
         # confusing, but at this moment in time events_dict is actually a
         # list of dicts that will be merged into one dictionary after this

--- a/pipit/readers/otf2_reader.py
+++ b/pipit/readers/otf2_reader.py
@@ -13,9 +13,15 @@ import pipit.trace
 class OTF2Reader:
     """Reader for OTF2 trace files"""
 
-    def __init__(self, dir_name):
+    def __init__(self, dir_name, num_parallel = None):
         self.dir_name = dir_name  # directory of otf2 file being read
         self.file_name = self.dir_name + "/traces.otf2"
+
+        num_cpus = mp.cpu_count()
+        if num_parallel is None or num_parallel < 1 or num_parallel > num_cpus:
+            self.num_parallel = math.floor(num_cpus * 0.75)
+        else:
+            self.num_parallel = num_parallel
 
     def field_to_val(self, field):
         """
@@ -311,8 +317,12 @@ class OTF2Reader:
 
         # parallelizes the reading of events
         # using the multiprocessing library
+<<<<<<< HEAD
         pool_size = mp.cpu_count()
         pool = mp.Pool(pool_size)
+=======
+        pool_size, pool = self.num_parallel, mp.Pool(self.num_parallel)
+>>>>>>> 327c13d (feature: give optional argument for number of cores to parallelize reader with)
 
         # confusing, but at this moment in time events_dict is actually a
         # list of dicts that will be merged into one dictionary after this

--- a/pipit/trace.py
+++ b/pipit/trace.py
@@ -17,12 +17,12 @@ class Trace:
         self.events = events
 
     @staticmethod
-    def from_otf2(dirname):
+    def from_otf2(dirname, num_parallel = None):
         """Read an OTF2 trace into a new Trace object."""
         # import this lazily to avoid circular dependencies
         from .readers.otf2_reader import OTF2Reader
 
-        return OTF2Reader(dirname).read()
+        return OTF2Reader(dirname, num_parallel).read()
 
     @staticmethod
     def from_hpctoolkit(dirname):

--- a/pipit/trace.py
+++ b/pipit/trace.py
@@ -17,7 +17,7 @@ class Trace:
         self.events = events
 
     @staticmethod
-    def from_otf2(dirname, num_parallel = None):
+    def from_otf2(dirname, num_parallel=None):
         """Read an OTF2 trace into a new Trace object."""
         # import this lazily to avoid circular dependencies
         from .readers.otf2_reader import OTF2Reader


### PR DESCRIPTION
- gives user option to choose how many cores to parallelize with
- uses floor(0.75 * num_cores) as default for parallelization
- concatenates dataframes instead of dictionaries