### PR TITLE
OTF2 Reader: Performance Improvements

### DIFF
--- a/pipit/readers/otf2_reader.py
+++ b/pipit/readers/otf2_reader.py
@@ -351,6 +351,16 @@ class OTF2Reader:
             by="Timestamp (ns)", axis=0, ascending=True, inplace=True, ignore_index=True
         )
 
+        # convert these to ints
+        # (sometimes they get converted to floats
+        #  while concatenating dataframes)
+        events_dataframe = events_dataframe.astype(
+            {
+                "Thread": "int32",
+                "Process": "int32"
+            }
+        )
+
         # using categorical dtypes for memory optimization
         # (only efficient when used for categorical data)
         events_dataframe = events_dataframe.astype(

--- a/pipit/readers/otf2_reader.py
+++ b/pipit/readers/otf2_reader.py
@@ -355,10 +355,7 @@ class OTF2Reader:
         # (sometimes they get converted to floats
         #  while concatenating dataframes)
         events_dataframe = events_dataframe.astype(
-            {
-                "Thread": "int32",
-                "Process": "int32"
-            }
+            {"Thread": "int32", "Process": "int32"}
         )
 
         # using categorical dtypes for memory optimization

--- a/pipit/trace.py
+++ b/pipit/trace.py
@@ -17,12 +17,12 @@ class Trace:
         self.events = events
 
     @staticmethod
-    def from_otf2(dirname):
+    def from_otf2(dirname, num_processes=None):
         """Read an OTF2 trace into a new Trace object."""
         # import this lazily to avoid circular dependencies
         from .readers.otf2_reader import OTF2Reader
 
-        return OTF2Reader(dirname).read()
+        return OTF2Reader(dirname, num_processes).read()
 
     @staticmethod
     def from_hpctoolkit(dirname):


### PR DESCRIPTION
- gives user option to choose how many cores to parallelize with
- uses max # of cores available as default for parallelization
- modifies distribution of trace files across processes for more even parallelization
- concatenates dataframes instead of dictionaries