### PR TITLE
Projections Reader - Updated event type to enter/leave

### DIFF
--- a/pipit/readers/projections_reader.py
+++ b/pipit/readers/projections_reader.py
@@ -311,7 +311,7 @@ class ProjectionsReader:
                 details = {"From PE": pe}
 
                 data["Name"].append("Idle")
-                data["Event Type"].append("Entry")
+                data["Event Type"].append("Enter")
                 data["Timestamp (ns)"].append(time)
                 data["Process ID"].append(pe_num)
                 data["Details"].append(details)
@@ -323,7 +323,7 @@ class ProjectionsReader:
                 details = {"From PE": pe}
 
                 data["Name"].append("Idle")
-                data["Event Type"].append("Exit")
+                data["Event Type"].append("Leave")
                 data["Timestamp (ns)"].append(time)
                 data["Process ID"].append(pe_num)
                 data["Details"].append(details)
@@ -336,7 +336,7 @@ class ProjectionsReader:
                 details = {"From PE": pe}
 
                 data["Name"].append("Pack")
-                data["Event Type"].append("Entry")
+                data["Event Type"].append("Enter")
                 data["Timestamp (ns)"].append(time)
                 data["Process ID"].append(pe_num)
                 data["Details"].append(details)
@@ -348,7 +348,7 @@ class ProjectionsReader:
                 details = {"From PE": pe}
 
                 data["Name"].append("Pack")
-                data["Event Type"].append("Exit")
+                data["Event Type"].append("Leave")
                 data["Timestamp (ns)"].append(time)
                 data["Process ID"].append(pe_num)
                 data["Details"].append(details)
@@ -361,7 +361,7 @@ class ProjectionsReader:
                 details = {"From PE": pe}
 
                 data["Name"].append("Unpack")
-                data["Event Type"].append("Entry")
+                data["Event Type"].append("Enter")
                 data["Timestamp (ns)"].append(time)
                 data["Process ID"].append(pe_num)
                 data["Details"].append(details)
@@ -373,7 +373,7 @@ class ProjectionsReader:
                 details = {"From PE": pe}
 
                 data["Name"].append("Unpack")
-                data["Event Type"].append("Exit")
+                data["Event Type"].append("Leave")
                 data["Timestamp (ns)"].append(time)
                 data["Process ID"].append(pe_num)
                 data["Details"].append(details)
@@ -419,13 +419,13 @@ class ProjectionsReader:
                 }
 
                 data["Name"].append("User Supplied Bracketed Note")
-                data["Event Type"].append("Entry")
+                data["Event Type"].append("Enter")
                 data["Timestamp (ns)"].append(time)
                 data["Process ID"].append(pe_num)
                 data["Details"].append(details)
 
                 data["Name"].append("User Supplied Bracketed Note")
-                data["Event Type"].append("Exit")
+                data["Event Type"].append("Leave")
                 data["Timestamp (ns)"].append(end_time)
                 data["Process ID"].append(pe_num)
                 data["Details"].append(details)
@@ -530,7 +530,7 @@ class ProjectionsReader:
                 }
 
                 data["Name"].append("Processing")
-                data["Event Type"].append("Entry")
+                data["Event Type"].append("Enter")
                 data["Timestamp (ns)"].append(time)
                 data["Process ID"].append(pe_num)
                 data["Details"].append(details)
@@ -559,7 +559,7 @@ class ProjectionsReader:
                 }
 
                 data["Name"].append("Processing")
-                data["Event Type"].append("Exit")
+                data["Event Type"].append("Leave")
                 data["Timestamp (ns)"].append(time)
                 data["Process ID"].append(pe_num)
                 data["Details"].append(sts_reader.get_entry_name(entry))
@@ -569,7 +569,7 @@ class ProjectionsReader:
                 time = int(line_arr[1])
 
                 data["Name"].append("Trace")
-                data["Event Type"].append("Entry")
+                data["Event Type"].append("Enter")
                 data["Timestamp (ns)"].append(time)
                 data["Process ID"].append(pe_num)
                 data["Details"].append(None)
@@ -578,7 +578,7 @@ class ProjectionsReader:
                 time = int(line_arr[1])
 
                 data["Name"].append("Trace")
-                data["Event Type"].append("Exit")
+                data["Event Type"].append("Leave")
                 data["Timestamp (ns)"].append(time)
                 data["Process ID"].append(pe_num)
                 data["Details"].append(None)
@@ -642,7 +642,7 @@ class ProjectionsReader:
                 details = {"From PE": pe, "Event ID": event}
 
                 data["Name"].append("Interrupt")
-                data["Event Type"].append("Entry")
+                data["Event Type"].append("Enter")
                 data["Timestamp (ns)"].append(time)
                 data["Process ID"].append(pe_num)
                 data["Details"].append(details)
@@ -655,7 +655,7 @@ class ProjectionsReader:
                 details = {"From PE": pe, "Event ID": event}
 
                 data["Name"].append("Interrupt")
-                data["Event Type"].append("Exit")
+                data["Event Type"].append("Leave")
                 data["Timestamp (ns)"].append(time)
                 data["Process ID"].append(pe_num)
                 data["Details"].append(details)
@@ -665,7 +665,7 @@ class ProjectionsReader:
                 time = int(line_arr[1])
 
                 data["Name"].append("Computation")
-                data["Event Type"].append("Entry")
+                data["Event Type"].append("Enter")
                 data["Timestamp (ns)"].append(time)
                 data["Process ID"].append(pe_num)
                 data["Details"].append(None)
@@ -674,7 +674,7 @@ class ProjectionsReader:
                 time = int(line_arr[1])
 
                 data["Name"].append("Computation")
-                data["Event Type"].append("Exit")
+                data["Event Type"].append("Leave")
                 data["Timestamp (ns)"].append(time)
                 data["Process ID"].append(pe_num)
                 data["Details"].append(None)
@@ -733,7 +733,7 @@ class ProjectionsReader:
                 }
 
                 data["Name"].append("User Event Pair")
-                data["Event Type"].append("Entry")
+                data["Event Type"].append("Enter")
                 data["Timestamp (ns)"].append(time)
                 data["Process ID"].append(pe_num)
                 data["Details"].append(details)
@@ -753,7 +753,7 @@ class ProjectionsReader:
                 }
 
                 data["Name"].append("User Event Pair")
-                data["Event Type"].append("Exit")
+                data["Event Type"].append("Leave")
                 data["Timestamp (ns)"].append(time)
                 data["Process ID"].append(pe_num)
                 data["Details"].append(details)


### PR DESCRIPTION
The event types on the projections reader were entry/exit, but updated to enter/leave to conform with the other readers