### PR TITLE
Trace: comm_summary and comm_over_time

### DIFF
--- a/pipit/tests/trace.py
+++ b/pipit/tests/trace.py
@@ -48,17 +48,17 @@ def test_comm_over_time(data_dir, ping_pong_otf2_trace):
     assert hist[4] == 8 * 2
 
 
-def test_comm_summary(data_dir, ping_pong_otf2_trace):
+def test_comm_by_process(data_dir, ping_pong_otf2_trace):
     ping_pong = Trace.from_otf2(str(ping_pong_otf2_trace))
 
-    sizes = ping_pong.comm_summary()
+    sizes = ping_pong.comm_by_process()
 
     assert sizes.loc[0]["Sent"] == 4177920
     assert sizes.loc[0]["Received"] == 4177920
     assert sizes.loc[1]["Sent"] == 4177920
     assert sizes.loc[1]["Received"] == 4177920
 
-    counts = ping_pong.comm_summary(output="count")
+    counts = ping_pong.comm_by_process(output="count")
 
     assert counts.loc[0]["Sent"] == 8
     assert counts.loc[0]["Received"] == 8

--- a/pipit/tests/trace.py
+++ b/pipit/tests/trace.py
@@ -35,15 +35,15 @@ def test_comm_matrix(data_dir, ping_pong_otf2_trace):
 def test_comm_over_time(data_dir, ping_pong_otf2_trace):
     ping_pong = Trace.from_otf2(str(ping_pong_otf2_trace))
 
-    hist, edges = ping_pong.comm_over_time(
-        output="size", message_type="send", bins=5
-    )
+    hist, edges = ping_pong.comm_over_time(output="size", message_type="send", bins=5)
 
     assert len(edges) == 6
     assert all(hist[0:3] == 0)
     assert hist[4] == 4177920 * 2
 
-    hist, edges = ping_pong.comm_over_time(output="count", message_type="receive", bins=5)
+    hist, edges = ping_pong.comm_over_time(
+        output="count", message_type="receive", bins=5
+    )
 
     assert len(edges) == 6
     assert all(hist[0:3] == 0)

--- a/pipit/tests/trace.py
+++ b/pipit/tests/trace.py
@@ -35,7 +35,9 @@ def test_comm_matrix(data_dir, ping_pong_otf2_trace):
 def test_comm_over_time(data_dir, ping_pong_otf2_trace):
     ping_pong = Trace.from_otf2(str(ping_pong_otf2_trace))
 
-    hist, edges = ping_pong.comm_over_time(output="size", message_type="send", bins=5)
+    hist, edges = ping_pong.comm_over_time(
+        output="size", message_type="send", bins=5
+    )
 
     assert len(edges) == 6
     assert all(hist[0:3] == 0)

--- a/pipit/tests/trace.py
+++ b/pipit/tests/trace.py
@@ -35,7 +35,7 @@ def test_comm_matrix(data_dir, ping_pong_otf2_trace):
 def test_comm_over_time(data_dir, ping_pong_otf2_trace):
     ping_pong = Trace.from_otf2(str(ping_pong_otf2_trace))
 
-    hist, edges = ping_pong.comm_over_time(output="bytes", message_type="send", bins=5)
+    hist, edges = ping_pong.comm_over_time(output="size", message_type="send", bins=5)
 
     assert len(edges) == 6
     assert all(hist[0:3] == 0)

--- a/pipit/tests/trace.py
+++ b/pipit/tests/trace.py
@@ -35,13 +35,13 @@ def test_comm_matrix(data_dir, ping_pong_otf2_trace):
 def test_comm_over_time(data_dir, ping_pong_otf2_trace):
     ping_pong = Trace.from_otf2(str(ping_pong_otf2_trace))
 
-    hist, edges = ping_pong.comm_over_time(output="size", kind="send", bins=5)
+    hist, edges = ping_pong.comm_over_time(output="bytes", message_type="send", bins=5)
 
     assert len(edges) == 6
     assert all(hist[0:3] == 0)
     assert hist[4] == 4177920 * 2
 
-    hist, edges = ping_pong.comm_over_time(output="counts", kind="receive", bins=5)
+    hist, edges = ping_pong.comm_over_time(output="count", message_type="receive", bins=5)
 
     assert len(edges) == 6
     assert all(hist[0:3] == 0)

--- a/pipit/tests/trace.py
+++ b/pipit/tests/trace.py
@@ -32,6 +32,40 @@ def test_comm_matrix(data_dir, ping_pong_otf2_trace):
     assert count_comm_matrix[0][1] == count_comm_matrix[1][0] == 8
 
 
+def test_comm_over_time(data_dir, ping_pong_otf2_trace):
+    ping_pong = Trace.from_otf2(str(ping_pong_otf2_trace))
+
+    hist, edges = ping_pong.comm_over_time(output="size", kind="send", bins=5)
+
+    assert len(edges) == 6
+    assert all(hist[0:3] == 0)
+    assert hist[4] == 4177920 * 2
+
+    hist, edges = ping_pong.comm_over_time(output="counts", kind="receive", bins=5)
+
+    assert len(edges) == 6
+    assert all(hist[0:3] == 0)
+    assert hist[4] == 8 * 2
+
+
+def test_comm_summary(data_dir, ping_pong_otf2_trace):
+    ping_pong = Trace.from_otf2(str(ping_pong_otf2_trace))
+
+    sizes = ping_pong.comm_summary()
+
+    assert sizes.loc[0]["Sent"] == 4177920
+    assert sizes.loc[0]["Received"] == 4177920
+    assert sizes.loc[1]["Sent"] == 4177920
+    assert sizes.loc[1]["Received"] == 4177920
+
+    counts = ping_pong.comm_summary(output="count")
+
+    assert counts.loc[0]["Sent"] == 8
+    assert counts.loc[0]["Received"] == 8
+    assert counts.loc[1]["Sent"] == 8
+    assert counts.loc[1]["Received"] == 8
+
+
 def test_match_events(data_dir, ping_pong_otf2_trace):
     trace = Trace.from_otf2(str(ping_pong_otf2_trace))
     trace._match_events()

--- a/pipit/trace.py
+++ b/pipit/trace.py
@@ -477,25 +477,18 @@ class Trace:
 
         # Get timestamps and sizes
         timestamps = events["Timestamp (ns)"]
-        processes = events["Process"].astype(float)
         sizes = events["Attributes"].apply(lambda x: x["msg_length"])
 
-        hist, edges, _ = np.histogram2d(
+        return np.histogram(
             timestamps,
-            processes,
-            bins=[bins, len(processes.unique())],
+            bins=bins,
             weights=sizes.tolist() if output == "size" else None,
             range=[
-                [
-                    self.events["Timestamp (ns)"].min(),
-                    self.events["Timestamp (ns)"].max(),
-                ],
-                None,
+                self.events["Timestamp (ns)"].min(),
+                self.events["Timestamp (ns)"].max(),
             ],
             **kwargs
         )
-
-        return np.transpose(hist), edges
 
     def comm_summary(self, output="size"):
         """Returns total communication volume per process.

--- a/pipit/trace.py
+++ b/pipit/trace.py
@@ -454,24 +454,27 @@ class Trace:
 
         return np.histogram(sizes, bins=bins, **kwargs)
 
-    def comm_over_time(self, output="size", kind="send", bins=50, **kwargs):
+    def comm_over_time(self, output="bytes", message_type="send", bins=50, **kwargs):
         """Returns histogram of communication volume over time.
 
         Args:
-            output (str, optional). Whether to measure volume by "count" or "size".
-                Defaults to "size".
-            kind (str, optional): Whether to compute for "send" or "receive". Defaults
-                to "send".
-            bins (int, optional): Number of bins in the histogram. Defaults to 50.
+            output (str, optional). Whether to measure volume by "count" or
+            "bytes". Defaults to "bytes".
+
+            message_type (str, optional): Whether to compute for sends or
+            receives. Defaults to "send".
+
+            bins (int, optional): Number of bins in the histogram. Defaults to
+            50.
 
         Returns:
-            hist: Volume in each time interval
+            hist: Volume in bytes or number of messages in each time interval
             edges: Edges of time intervals
         """
         # Filter by send or receive events
         events = self.events[
             self.events["Name"].isin(
-                ["MpiSend", "MpiIsend"] if kind == "send" else ["MpiRecv", "MpiIrecv"]
+                ["MpiSend", "MpiIsend"] if message_type == "send" else ["MpiRecv", "MpiIrecv"]
             )
         ]
 
@@ -491,11 +494,12 @@ class Trace:
         )
 
     def comm_by_process(self, output="size"):
-        """Returns total communication volume per process.
+        """Returns total communication volume in bytes of number of messagsper
+           process.
 
         Returns:
-            pd.DataFrame: DataFrame containing total communication volume sent and
-                received in each process
+            pd.DataFrame: DataFrame containing total communication volume or
+            number of messags sent and received by each process.
         """
         comm_matrix = self.comm_matrix(output=output)
 

--- a/pipit/trace.py
+++ b/pipit/trace.py
@@ -454,12 +454,12 @@ class Trace:
 
         return np.histogram(sizes, bins=bins, **kwargs)
 
-    def comm_over_time(self, output="bytes", message_type="send", bins=50, **kwargs):
+    def comm_over_time(self, output="size", message_type="send", bins=50, **kwargs):
         """Returns histogram of communication volume over time.
 
         Args:
-            output (str, optional). Whether to measure volume by "count" or
-            "bytes". Defaults to "bytes".
+            output (str, optional). Whether to calculate communication by "count" or
+            "size". Defaults to "size".
 
             message_type (str, optional): Whether to compute for sends or
             receives. Defaults to "send".
@@ -468,7 +468,7 @@ class Trace:
             50.
 
         Returns:
-            hist: Volume in bytes or number of messages in each time interval
+            hist: Volume in size or number of messages in each time interval
             edges: Edges of time intervals
         """
         # Filter by send or receive events
@@ -494,7 +494,7 @@ class Trace:
         )
 
     def comm_by_process(self, output="size"):
-        """Returns total communication volume in bytes of number of messagsper
+        """Returns total communication volume in size or number of messages per
            process.
 
         Returns:

--- a/pipit/trace.py
+++ b/pipit/trace.py
@@ -494,7 +494,8 @@ class Trace:
         """Returns total communication volume per process.
 
         Returns:
-            _type_: _description_
+            pd.DataFrame: DataFrame containing total communication volume sent and
+                received in each process
         """
         comm_matrix = self.comm_matrix(output=output)
 

--- a/pipit/trace.py
+++ b/pipit/trace.py
@@ -477,18 +477,25 @@ class Trace:
 
         # Get timestamps and sizes
         timestamps = events["Timestamp (ns)"]
+        processes = events["Process"].astype(float)
         sizes = events["Attributes"].apply(lambda x: x["msg_length"])
 
-        return np.histogram(
+        hist, edges, _ = np.histogram2d(
             timestamps,
-            bins=bins,
-            weights=sizes if output == "size" else None,
+            processes,
+            bins=[bins, len(processes.unique())],
+            weights=sizes.tolist() if output == "size" else None,
             range=[
-                self.events["Timestamp (ns)"].min(),
-                self.events["Timestamp (ns)"].max(),
+                [
+                    self.events["Timestamp (ns)"].min(),
+                    self.events["Timestamp (ns)"].max(),
+                ],
+                None,
             ],
             **kwargs
         )
+
+        return np.transpose(hist), edges
 
     def comm_summary(self, output="size"):
         """Returns total communication volume per process.

--- a/pipit/trace.py
+++ b/pipit/trace.py
@@ -490,7 +490,7 @@ class Trace:
             **kwargs
         )
 
-    def comm_summary(self, output="size"):
+    def comm_by_process(self, output="size"):
         """Returns total communication volume per process.
 
         Returns:

--- a/pipit/trace.py
+++ b/pipit/trace.py
@@ -454,9 +454,60 @@ class Trace:
 
         return np.histogram(sizes, bins=bins, **kwargs)
 
+    def comm_over_time(self, output="size", kind="send", bins=50, **kwargs):
+        """Returns histogram of communication volume over time.
+
+        Args:
+            output (str, optional). Whether to measure volume by "count" or "size".
+                Defaults to "size".
+            kind (str, optional): Whether to compute for "send" or "receive". Defaults
+                to "send".
+            bins (int, optional): Number of bins in the histogram. Defaults to 50.
+
+        Returns:
+            hist: Volume in each time interval
+            edges: Edges of time intervals
+        """
+        # Filter by send or receive events
+        events = self.events[
+            self.events["Name"].isin(
+                ["MpiSend", "MpiIsend"] if kind == "send" else ["MpiRecv", "MpiIrecv"]
+            )
+        ]
+
+        # Get timestamps and sizes
+        timestamps = events["Timestamp (ns)"]
+        sizes = events["Attributes"].apply(lambda x: x["msg_length"])
+
+        return np.histogram(
+            timestamps,
+            bins=bins,
+            weights=sizes if output == "size" else None,
+            range=[
+                self.events["Timestamp (ns)"].min(),
+                self.events["Timestamp (ns)"].max(),
+            ],
+            **kwargs
+        )
+
+    def comm_summary(self, output="size"):
+        """Returns total communication volume per process.
+
+        Returns:
+            _type_: _description_
+        """
+        comm_matrix = self.comm_matrix(output=output)
+
+        # Get total sent and received for each process
+        sent = comm_matrix.sum(axis=1)
+        received = comm_matrix.sum(axis=0)
+
+        return pd.DataFrame({"Sent": sent, "Received": received}).rename_axis("Process")
+
     def flat_profile(
         self, metrics="time.exc", groupby_column="Name", per_process=False
     ):
+
         """
         Arguments:
         metrics - a string or list of strings containing the metrics to be aggregated

--- a/pipit/trace.py
+++ b/pipit/trace.py
@@ -474,7 +474,9 @@ class Trace:
         # Filter by send or receive events
         events = self.events[
             self.events["Name"].isin(
-                ["MpiSend", "MpiIsend"] if message_type == "send" else ["MpiRecv", "MpiIrecv"]
+                ["MpiSend", "MpiIsend"]
+                if message_type == "send"
+                else ["MpiRecv", "MpiIrecv"]
             )
         ]
 
@@ -512,7 +514,6 @@ class Trace:
     def flat_profile(
         self, metrics="time.exc", groupby_column="Name", per_process=False
     ):
-
         """
         Arguments:
         metrics - a string or list of strings containing the metrics to be aggregated


### PR DESCRIPTION
- **comm_summary** computes total message count/volume sent and received per process

![image](https://user-images.githubusercontent.com/41878376/230222531-178d5221-9393-48e3-ac98-3bc6b11c0e9a.png)


- **comm_over_time** computes total message count/volume sent over time

![image](https://user-images.githubusercontent.com/41878376/230222559-344ae078-0af1-4304-ab64-a643eed68029.png)

