### PR TITLE
fix flake8 and black

### DIFF
--- a/pipit/readers/otf2_reader.py
+++ b/pipit/readers/otf2_reader.py
@@ -316,9 +316,9 @@ class OTF2Reader:
                                 if value is not None and key != "time":
                                     # uses field_to_val to convert all data types
                                     # and ensure that there are no pickling errors
-                                    attributes_dict[
-                                        self.field_to_val(key)
-                                    ] = self.handle_data(value)
+                                    attributes_dict[self.field_to_val(key)] = (
+                                        self.handle_data(value)
+                                    )
                             event_attributes.append(attributes_dict)
                         else:
                             # nan attributes for leave rows

--- a/pipit/readers/projections_reader.py
+++ b/pipit/readers/projections_reader.py
@@ -513,10 +513,10 @@ class ProjectionsReader:
                     pe = int(line_arr[5])
                     msglen = int(line_arr[6])
                     send_time = int(line_arr[7]) * 1000
-                    numPEs = int(line_arr[8])
-                    destPEs = []
-                    for i in (0, numPEs):
-                        destPEs.append(int(line_arr[9 + i]))
+                    num_procs = int(line_arr[8])
+                    dest_procs = []
+                    for i in (0, num_procs):
+                        dest_procs.append(int(line_arr[9 + i]))
 
                     details = {
                         "From PE": pe,
@@ -525,7 +525,7 @@ class ProjectionsReader:
                         "Message Length": msglen,
                         "Event ID": event,
                         "Send Time": send_time,
-                        "Destinatopn PEs": destPEs,
+                        "Destinatopn PEs": dest_procs,
                     }
 
                     _add_to_trace_dict(
@@ -534,7 +534,7 @@ class ProjectionsReader:
                         "Instant",
                         time,
                         pe_num,
-                        "To " + str(numPEs) + "processors",
+                        "To " + str(num_procs) + "processors",
                     )
 
                 # Processing of chare (i.e. execution) ?

--- a/pipit/trace.py
+++ b/pipit/trace.py
@@ -597,7 +597,7 @@ class Trace:
 
         return imbalance_df
 
-    def idle_time(self, idle_functions=["Idle"], MPI_events=False):
+    def idle_time(self, idle_functions=["Idle"], mpi_events=False):
         # dict for creating a new dataframe
         idle_times = {"Process": [], "Idle Time": []}
 
@@ -605,19 +605,19 @@ class Trace:
             idle_times["Process"].append(process)
             idle_times["Idle Time"].append(
                 self._calculate_idle_time_for_process(
-                    process, idle_functions, MPI_events
+                    process, idle_functions, mpi_events
                 )
             )
         return pd.DataFrame(idle_times)
 
     def _calculate_idle_time_for_process(
-        self, process, idle_functions=["Idle"], MPI_events=False
+        self, process, idle_functions=["Idle"], mpi_events=False
     ):
         # calculate inclusive metrics
         if "time.inc" not in self.events.columns:
             self.calc_inc_metrics()
 
-        if MPI_events:
+        if mpi_events:
             idle_functions += ["MPI_Wait", "MPI_Waitall", "MPI_Recv"]
         # filter the dataframe to include only 'Enter' events within the specified
         # process with the specified function names

--- a/pipit/util/cct.py
+++ b/pipit/util/cct.py
@@ -86,9 +86,11 @@ def create_cct(events):
 
                     # add node as root or child of its
                     # parent depending on current depth
-                    graph.add_root(
-                        curr_node
-                    ) if curr_depth == 0 else parent_node.add_child(curr_node)
+                    (
+                        graph.add_root(curr_node)
+                        if curr_depth == 0
+                        else parent_node.add_child(curr_node)
+                    )
 
                 # Update nodes stack, column, and current depth
                 nodes_stack.append(curr_node)


### PR DESCRIPTION
develop fails because of `black` issues:
```
would reformat /home/rakrish/pipit/pipit/util/cct.py
would reformat /home/rakrish/pipit/pipit/readers/otf2_reader.py

Oh no! 💥 💔 💥
```

and `flake8` issues;
```
./pipit/readers/projections_reader.py:516:22: N806 variable 'numPEs' in function should be lowercase
./pipit/readers/projections_reader.py:517:22: N806 variable 'destPEs' in function should be lowercase
./pipit/trace.py:600:51: N803 argument name 'MPI_events' should be lowercase
./pipit/trace.py:614:50: N803 argument name 'MPI_events' should be lowercase
```

This PR fixes them.