### PR TITLE
Add Nsight SQLite reader

### DIFF
--- a/pipit/readers/nsight_sqlite_reader.py
+++ b/pipit/readers/nsight_sqlite_reader.py
@@ -1,0 +1,306 @@
+import numpy as np
+import pandas as pd
+
+import pipit.trace
+from pipit.graph import Graph, Node
+import sqlite3
+
+"""Need to read from the following tables:
+- CUPTI_ACTIVITY_KIND_RUNTIME
+- CUPTI_ACTIVITY_KIND_KERNEL
+- CUPTI_ACTIVITY_KIND_MEMSET
+- CUPTI_ACTIVITY_KIND_MEMCPY
+- NVTX_EVENTS
+
+Times are in nanoseconds
+"""
+class NSightSQLiteReader:
+    # Dictionary mapping trace type
+    # (e.g. NVTX,
+    _trace_queries = {
+        # TODO: this is untested, find an application with nvtx
+        # support
+        # also likely broken from recent changes to this reader
+        # "nvtx": ["""
+        # SELECT
+        #     start as Enter,
+        #     end as Leave,
+        #     'annotation' as type,
+        #     rname.value AS Name,
+        #     (ne.globalTid >> 24) & 0x00FFFFFF AS "Process",
+        #     ne.globalTid & 0x00FFFFFF AS "Thread"
+        # FROM
+        #     NVTX_EVENTS as ne
+        # JOIN ThreadNames AS tname
+        #     ON ne.globalTid == tname.globalTid
+        # JOIN
+        #     StringIds AS rname
+        #     ON ne.textId = rname.id
+        # JOIN
+        #     StringIds AS rname2
+        #     ON tname.nameId = rname2.id
+        # """],
+        "nvtx": ["""
+        SELECT
+            start as Enter,
+            end as Leave,
+            'annotation' as type,
+            IFNULL(text, StringIds.value) as "Name",
+            (ne.globalTid >> 24) & 0x00FFFFFF AS "Process",
+            ne.globalTid & 0x00FFFFFF AS "Thread",
+            jsonText as meta
+        FROM
+            NVTX_EVENTS as ne
+        LEFT JOIN StringIds
+            ON StringIds.id = ne.textId
+        """],
+        # TODO: verify that the code for extracting process and
+        # thread id is correct
+        "cuda_api": ["""
+        SELECT
+            start as Enter,
+            end as Leave,
+            rname.value AS Name,
+            (cuda_api.globalTid >> 24) & 0x00FFFFFF AS "Process",
+            cuda_api.globalTid & 0x00FFFFFF AS "Thread",
+            correlationId As id,
+            null as meta
+        FROM
+            CUPTI_ACTIVITY_KIND_RUNTIME as cuda_api
+        JOIN ThreadNames AS tname
+            ON cuda_api.globalTid == tname.globalTid
+        JOIN
+            StringIds AS rname
+            ON cuda_api.nameId = rname.id
+        JOIN
+            StringIds AS rname2
+            ON tname.nameId = rname2.id
+        """],
+        "gpu_trace": ["""
+        SELECT
+            cuda_gpu.start as Enter,
+            cuda_gpu.end as Leave,
+            cuda_gpu.deviceId as gpuId,
+            value as Name,
+            cuda_gpu.streamId,
+            'kernel' as type,
+            null as bytes,
+            cuda_gpu.correlationId as id,
+            (cuda_api.globalTid >> 24) & 0x00FFFFFF AS "Process",
+            null as meta
+        FROM CUPTI_ACTIVITY_KIND_KERNEL as cuda_gpu
+        JOIN StringIds
+            ON cuda_gpu.shortName = StringIds.id
+        JOIN CUPTI_ACTIVITY_KIND_RUNTIME as cuda_api
+            ON cuda_gpu.correlationId = cuda_api.correlationId
+        """,
+        """
+        SELECT
+            cuda_memcpy.start as Enter,
+            cuda_memcpy.end as Leave,
+            cuda_memcpy.deviceId as gpuId,
+            memcpy_labels.name as Name,
+            cuda_memcpy.streamId,
+            'cuda_memcpy' as type,
+            bytes,
+            cuda_memcpy.correlationId as id,
+            (cuda_api.globalTid >> 24) & 0x00FFFFFF AS "Process",
+            null as meta
+        FROM CUPTI_ACTIVITY_KIND_MEMCPY as cuda_memcpy
+        JOIN ENUM_CUDA_MEMCPY_OPER as memcpy_labels
+            ON cuda_memcpy.copyKind = memcpy_labels.id
+        JOIN CUPTI_ACTIVITY_KIND_RUNTIME as cuda_api
+            ON cuda_memcpy.correlationId = cuda_api.correlationId
+        """,
+        """
+        SELECT
+            cuda_memset.start as Enter,
+            cuda_memset.end as Leave,
+            cuda_memset.deviceId as gpuId,
+            memset_labels.name as Name,
+            streamId,
+            'cuda_memset' as type,
+            bytes,
+            cuda_memset.correlationId as id,
+            (cuda_api.globalTid >> 24) & 0x00FFFFFF AS "Process",
+            null as meta
+        FROM CUPTI_ACTIVITY_KIND_MEMSET as cuda_memset
+        JOIN ENUM_CUDA_MEM_KIND as memset_labels
+            ON cuda_memset.memKind = memset_labels.id
+        JOIN CUPTI_ACTIVITY_KIND_RUNTIME as cuda_api
+            ON cuda_memset.correlationId = cuda_api.correlationId
+        """,
+        """
+        SELECT
+            cuda_sync.start as Enter,
+            cuda_sync.end as Leave,
+            cuda_sync.deviceId as gpuId,
+            sync_labels.name as Name,
+            cuda_sync.streamId,
+            'cuda_sync' as type,
+            null as bytes,
+            cuda_sync.correlationId as id,
+            (cuda_api.globalTid >> 24) & 0x00FFFFFF AS "Process",
+            null as meta
+        FROM CUPTI_ACTIVITY_KIND_SYNCHRONIZATION as cuda_sync
+        JOIN ENUM_CUPTI_SYNC_TYPE as sync_labels
+            ON cuda_sync.syncType = sync_labels.id
+        JOIN CUPTI_ACTIVITY_KIND_RUNTIME as cuda_api
+            ON cuda_sync.correlationId = cuda_api.correlationId
+        """,
+        """
+        SELECT
+            cuda_graph.start as Enter,
+            cuda_graph.end as Leave,
+            cuda_graph.deviceId as gpuId,
+            -- CUDA Graphs are not name-able, so we use their id
+            -- instead
+            'CUDA Graph ' || cuda_graph.graphId as Name,
+            cuda_graph.streamId,
+            'cuda_graph' as type,
+            null as bytes,
+            cuda_graph.correlationId as id,
+            (cuda_api.globalTid >> 24) & 0x00FFFFFF AS "Process",
+            null as meta
+        FROM CUPTI_ACTIVITY_KIND_GRAPH_TRACE as cuda_graph
+        JOIN CUPTI_ACTIVITY_KIND_RUNTIME as cuda_api
+            ON cuda_graph.correlationId = cuda_api.correlationId
+        """,
+        ]
+        # TODO: reading in all the gpu metrics takes up a lot of memory
+        # We should figure out which ones we want exactly
+        # "gpu_metrics": """
+        #     SELECT GENERIC_EVENTS.rawTimestamp, typeId, data
+        #     FROM GPU_METRICS
+        #     LEFT JOIN GENERIC_EVENTS
+        #     ON GENERIC_EVENTS.typeId = GPU_METRICS.typeId
+        # """
+    }
+    def __init__(self, filepath, create_cct=False, trace_types="all") -> None:
+        self.conn = sqlite3.connect(filepath)
+        self.create_cct = create_cct
+        # Get all the table names that exist
+        # Sometimes, things like the GPU metrics and stuff might not
+        # exist
+        get_tables_query = """
+        SELECT name FROM sqlite_master WHERE type='table'
+        """
+        self.table_names = set(pd.read_sql_query(get_tables_query, self.conn).squeeze())
+        self.trace_queries = NSightSQLiteReader._trace_queries.copy()
+        if trace_types == "all":
+            # TODO: Not sure this option makes that much sense anymore
+            # Even nsight has separate analyses for CUDA API summary, etc.
+            # We do need a way to compare multiple traces side by side, though
+
+            # Some traces (their tables, e.g. NVTX_EVENTS) may not always be present
+            # in the sqlite db
+            # Make sure that all tables that we read in queries are accounted for here
+            self.trace_types = []
+            if "NVTX_EVENTS" in self.table_names:
+                self.trace_types.append("nvtx")
+            if "CUPTI_ACTIVITY_KIND_RUNTIME" in self.table_names:
+                self.trace_types.append("cuda_api")
+                self.trace_types.append("gpu_trace")
+
+            # GPU metrics are disabled, see comment above
+            # if "GPU_METRICS" in self.table_names:
+            #     self.trace_types.append("gpu_metrics")
+        else:
+            self.trace_types = trace_types
+
+        if "gpu_trace" in self.trace_types:
+            # Check for existance of CUDA_ACTIVITY_KIND_MEMCPY/
+            # CUDA_ACTIVITY_KIND_MEMSET since those can sometimes not exist
+
+            gpu_trace_qs = []
+            gpu_trace_needed_tbls = ["CUPTI_ACTIVITY_KIND_RUNTIME", "CUPTI_ACTIVITY_KIND_MEMCPY",
+                                     "CUPTI_ACTIVITY_KIND_MEMSET", "CUPTI_ACTIVITY_KIND_SYNCHRONIZATION",
+                                     "CUPTI_ACTIVITY_KIND_GRAPH_TRACE"]
+
+            for req_tbl, q in zip(gpu_trace_needed_tbls, NSightSQLiteReader._trace_queries["gpu_trace"], strict=True):
+                if req_tbl in self.table_names:
+                    gpu_trace_qs.append(q)
+            self.trace_queries["gpu_trace"] = gpu_trace_qs
+
+    def read(self) -> pipit.trace.Trace:
+        traces = []
+
+        for typ in self.trace_types:
+            dfs = []
+            for q in self.trace_queries[typ]:
+                dfs.append(pd.read_sql_query(q, con=self.conn))
+            df = pd.concat(dfs, axis=0)
+            df["Trace Type"] = typ
+            traces.append(df)
+
+        # concat traces together row wise
+        trace_df = pd.concat(traces, axis=0)
+
+        # Melt start/end columns into single event type column
+        trace_df = pd.melt(trace_df,
+                # These are the columns we don't want to melt
+                # Columns not in here will be melted into a single column
+                id_vars=[col for col in df.columns if col not in {"Enter", "Leave"}],
+                value_vars=["Enter", "Leave"],
+                var_name="Event Type",
+                value_name="Timestamp (ns)")
+
+        if "bytes" in trace_df.columns:
+            trace_df = trace_df.astype(
+                {
+                    "bytes": "Int64",
+                }
+            )
+
+        # Cache mapping
+        trace_df["_matching_event"] = np.concatenate([np.arange(len(trace_df) // 2, len(trace_df)), np.arange(0, len(trace_df) // 2)])
+        # Convert to numpy before assignment otherwise pandas
+        # will try to align indices, which will mess up order
+        trace_df['_matching_timestamp'] = trace_df["Timestamp (ns)"][trace_df["_matching_event"]].to_numpy()
+
+        trace_df["_depth"] = 0
+        trace_df["_parent"] = None
+        trace_df["_children"] = None
+
+        # Associate CUDA API calls with memory operations or
+        # kernel launches
+        # Note: looking at _match_caller_callee
+        # _parent should point to the "Enter" event of the parent
+        # _children also points to the "Enter" events of the children of 1 node
+
+        enter_mask = trace_df["Event Type"] == "Enter"
+        cuda_api_mask = trace_df["Trace Type"] == "cuda_api"
+        calls_that_launch = trace_df.loc[cuda_api_mask & enter_mask].reset_index().merge(
+            trace_df.loc[~cuda_api_mask & enter_mask].reset_index(), on="id", how="inner"
+        )
+        # TODO: can get rid of the apply if we use an Arrow ListDtype for children
+        # globally
+        children = calls_that_launch["index_y"].apply(lambda x: [x])
+        # Convert to numpy otherwise the index messes stuff up
+        trace_df.loc[calls_that_launch["index_x"].to_numpy(), "_children"] = children.to_numpy()
+        trace_df.loc[calls_that_launch["index_y"].to_numpy(), "_parent"] = calls_that_launch["index_x"].to_numpy()
+
+        # Follow _match_caller_callee
+        # _match_caller_callee also converts to a categorical of Int32
+        trace_df = trace_df.astype({"_depth": "Int32", "_parent": "Int32"})
+        trace_df = trace_df.astype(
+            {"_depth": "category", "_parent": "category"}
+        )
+
+        # Cannot use ignore_index = True since that breaks the
+        # _matching_event col
+        trace_df = trace_df.sort_values(by="Timestamp (ns)")
+
+        if self.trace_types == ["gpu_trace"]:
+            parallelism_levels = ["gpuId", "streamId"]
+        elif self.trace_types == ["cuda_api"]:
+            # All CUDA calls in the same process/context are sequential?
+            # TODO: this should also map thread
+            parallelism_levels = ["Process"]
+        else:
+            parallelism_levels = ["Process", "gpuId", "streamId"]
+
+        trace = pipit.trace.Trace(None, trace_df, parallelism_levels=parallelism_levels)
+        if self.create_cct:
+            trace.create_cct()
+        return trace

--- a/pipit/readers/nsight_sqlite_reader.py
+++ b/pipit/readers/nsight_sqlite_reader.py
@@ -24,8 +24,6 @@ class NSightSQLiteReader:
             ON StringIds.id = ne.textId
         """
         ],
-        # TODO: verify that the code for extracting process and
-        # thread id is correct
         "cuda_api": [
             """
         SELECT
@@ -162,7 +160,6 @@ class NSightSQLiteReader:
         self.table_names = set(pd.read_sql_query(get_tables_query, self.conn).squeeze())
         self.trace_queries = NSightSQLiteReader._trace_queries.copy()
         if trace_types == "all":
-            # TODO: Not sure this option makes that much sense anymore
             # Even nsight has separate analyses for CUDA API summary, etc.
             # We do need a way to compare multiple traces side by side, though
 
@@ -293,8 +290,6 @@ class NSightSQLiteReader:
         if self.trace_types == ["gpu_trace"]:
             parallelism_levels = ["gpuId", "streamId"]
         elif self.trace_types == ["cuda_api"]:
-            # All CUDA calls in the same process/context are sequential?
-            # TODO: this should also map thread
             parallelism_levels = ["Process"]
         else:
             parallelism_levels = ["Process", "gpuId", "streamId"]

--- a/pipit/readers/nsight_sqlite_reader.py
+++ b/pipit/readers/nsight_sqlite_reader.py
@@ -6,7 +6,7 @@ import sqlite3
 
 class NSightSQLiteReader:
     # Dictionary mapping trace type
-    # (e.g. NVTX,
+    # (e.g. NVTX, CUDA API to SQL queries)
     _trace_queries = {
         "nvtx": [
             """

--- a/pipit/readers/nsight_sqlite_reader.py
+++ b/pipit/readers/nsight_sqlite_reader.py
@@ -14,6 +14,8 @@ import sqlite3
 
 Times are in nanoseconds
 """
+
+
 class NSightSQLiteReader:
     # Dictionary mapping trace type
     # (e.g. NVTX,
@@ -40,7 +42,8 @@ class NSightSQLiteReader:
         #     StringIds AS rname2
         #     ON tname.nameId = rname2.id
         # """],
-        "nvtx": ["""
+        "nvtx": [
+            """
         SELECT
             start as Enter,
             end as Leave,
@@ -53,10 +56,12 @@ class NSightSQLiteReader:
             NVTX_EVENTS as ne
         LEFT JOIN StringIds
             ON StringIds.id = ne.textId
-        """],
+        """
+        ],
         # TODO: verify that the code for extracting process and
         # thread id is correct
-        "cuda_api": ["""
+        "cuda_api": [
+            """
         SELECT
             start as Enter,
             end as Leave,
@@ -75,8 +80,10 @@ class NSightSQLiteReader:
         JOIN
             StringIds AS rname2
             ON tname.nameId = rname2.id
-        """],
-        "gpu_trace": ["""
+        """
+        ],
+        "gpu_trace": [
+            """
         SELECT
             cuda_gpu.start as Enter,
             cuda_gpu.end as Leave,
@@ -94,7 +101,7 @@ class NSightSQLiteReader:
         JOIN CUPTI_ACTIVITY_KIND_RUNTIME as cuda_api
             ON cuda_gpu.correlationId = cuda_api.correlationId
         """,
-        """
+            """
         SELECT
             cuda_memcpy.start as Enter,
             cuda_memcpy.end as Leave,
@@ -112,7 +119,7 @@ class NSightSQLiteReader:
         JOIN CUPTI_ACTIVITY_KIND_RUNTIME as cuda_api
             ON cuda_memcpy.correlationId = cuda_api.correlationId
         """,
-        """
+            """
         SELECT
             cuda_memset.start as Enter,
             cuda_memset.end as Leave,
@@ -130,7 +137,7 @@ class NSightSQLiteReader:
         JOIN CUPTI_ACTIVITY_KIND_RUNTIME as cuda_api
             ON cuda_memset.correlationId = cuda_api.correlationId
         """,
-        """
+            """
         SELECT
             cuda_sync.start as Enter,
             cuda_sync.end as Leave,
@@ -148,7 +155,7 @@ class NSightSQLiteReader:
         JOIN CUPTI_ACTIVITY_KIND_RUNTIME as cuda_api
             ON cuda_sync.correlationId = cuda_api.correlationId
         """,
-        """
+            """
         SELECT
             cuda_graph.start as Enter,
             cuda_graph.end as Leave,
@@ -166,7 +173,7 @@ class NSightSQLiteReader:
         JOIN CUPTI_ACTIVITY_KIND_RUNTIME as cuda_api
             ON cuda_graph.correlationId = cuda_api.correlationId
         """,
-        ]
+        ],
         # TODO: reading in all the gpu metrics takes up a lot of memory
         # We should figure out which ones we want exactly
         # "gpu_metrics": """
@@ -176,6 +183,7 @@ class NSightSQLiteReader:
         #     ON GENERIC_EVENTS.typeId = GPU_METRICS.typeId
         # """
     }
+
     def __init__(self, filepath, create_cct=False, trace_types="all") -> None:
         self.conn = sqlite3.connect(filepath)
         self.create_cct = create_cct
@@ -213,11 +221,19 @@ class NSightSQLiteReader:
             # CUDA_ACTIVITY_KIND_MEMSET since those can sometimes not exist
 
             gpu_trace_qs = []
-            gpu_trace_needed_tbls = ["CUPTI_ACTIVITY_KIND_RUNTIME", "CUPTI_ACTIVITY_KIND_MEMCPY",
-                                     "CUPTI_ACTIVITY_KIND_MEMSET", "CUPTI_ACTIVITY_KIND_SYNCHRONIZATION",
-                                     "CUPTI_ACTIVITY_KIND_GRAPH_TRACE"]
+            gpu_trace_needed_tbls = [
+                "CUPTI_ACTIVITY_KIND_RUNTIME",
+                "CUPTI_ACTIVITY_KIND_MEMCPY",
+                "CUPTI_ACTIVITY_KIND_MEMSET",
+                "CUPTI_ACTIVITY_KIND_SYNCHRONIZATION",
+                "CUPTI_ACTIVITY_KIND_GRAPH_TRACE",
+            ]
 
-            for req_tbl, q in zip(gpu_trace_needed_tbls, NSightSQLiteReader._trace_queries["gpu_trace"], strict=True):
+            for req_tbl, q in zip(
+                gpu_trace_needed_tbls,
+                NSightSQLiteReader._trace_queries["gpu_trace"],
+                strict=True,
+            ):
                 if req_tbl in self.table_names:
                     gpu_trace_qs.append(q)
             self.trace_queries["gpu_trace"] = gpu_trace_qs
@@ -237,13 +253,15 @@ class NSightSQLiteReader:
         trace_df = pd.concat(traces, axis=0)
 
         # Melt start/end columns into single event type column
-        trace_df = pd.melt(trace_df,
-                # These are the columns we don't want to melt
-                # Columns not in here will be melted into a single column
-                id_vars=[col for col in df.columns if col not in {"Enter", "Leave"}],
-                value_vars=["Enter", "Leave"],
-                var_name="Event Type",
-                value_name="Timestamp (ns)")
+        trace_df = pd.melt(
+            trace_df,
+            # These are the columns we don't want to melt
+            # Columns not in here will be melted into a single column
+            id_vars=[col for col in df.columns if col not in {"Enter", "Leave"}],
+            value_vars=["Enter", "Leave"],
+            var_name="Event Type",
+            value_name="Timestamp (ns)",
+        )
 
         if "bytes" in trace_df.columns:
             trace_df = trace_df.astype(
@@ -253,10 +271,17 @@ class NSightSQLiteReader:
             )
 
         # Cache mapping
-        trace_df["_matching_event"] = np.concatenate([np.arange(len(trace_df) // 2, len(trace_df)), np.arange(0, len(trace_df) // 2)])
+        trace_df["_matching_event"] = np.concatenate(
+            [
+                np.arange(len(trace_df) // 2, len(trace_df)),
+                np.arange(0, len(trace_df) // 2),
+            ]
+        )
         # Convert to numpy before assignment otherwise pandas
         # will try to align indices, which will mess up order
-        trace_df['_matching_timestamp'] = trace_df["Timestamp (ns)"][trace_df["_matching_event"]].to_numpy()
+        trace_df["_matching_timestamp"] = trace_df["Timestamp (ns)"][
+            trace_df["_matching_event"]
+        ].to_numpy()
 
         trace_df["_depth"] = 0
         trace_df["_parent"] = None
@@ -270,22 +295,30 @@ class NSightSQLiteReader:
 
         enter_mask = trace_df["Event Type"] == "Enter"
         cuda_api_mask = trace_df["Trace Type"] == "cuda_api"
-        calls_that_launch = trace_df.loc[cuda_api_mask & enter_mask].reset_index().merge(
-            trace_df.loc[~cuda_api_mask & enter_mask].reset_index(), on="id", how="inner"
+        calls_that_launch = (
+            trace_df.loc[cuda_api_mask & enter_mask]
+            .reset_index()
+            .merge(
+                trace_df.loc[~cuda_api_mask & enter_mask].reset_index(),
+                on="id",
+                how="inner",
+            )
         )
         # TODO: can get rid of the apply if we use an Arrow ListDtype for children
         # globally
         children = calls_that_launch["index_y"].apply(lambda x: [x])
         # Convert to numpy otherwise the index messes stuff up
-        trace_df.loc[calls_that_launch["index_x"].to_numpy(), "_children"] = children.to_numpy()
-        trace_df.loc[calls_that_launch["index_y"].to_numpy(), "_parent"] = calls_that_launch["index_x"].to_numpy()
+        trace_df.loc[calls_that_launch["index_x"].to_numpy(), "_children"] = (
+            children.to_numpy()
+        )
+        trace_df.loc[calls_that_launch["index_y"].to_numpy(), "_parent"] = (
+            calls_that_launch["index_x"].to_numpy()
+        )
 
         # Follow _match_caller_callee
         # _match_caller_callee also converts to a categorical of Int32
         trace_df = trace_df.astype({"_depth": "Int32", "_parent": "Int32"})
-        trace_df = trace_df.astype(
-            {"_depth": "category", "_parent": "category"}
-        )
+        trace_df = trace_df.astype({"_depth": "category", "_parent": "category"})
 
         # Cannot use ignore_index = True since that breaks the
         # _matching_event col

--- a/pipit/readers/nsight_sqlite_reader.py
+++ b/pipit/readers/nsight_sqlite_reader.py
@@ -1,46 +1,13 @@
 import numpy as np
 import pandas as pd
-
 import pipit.trace
 import sqlite3
-
-"""Need to read from the following tables:
-- CUPTI_ACTIVITY_KIND_RUNTIME
-- CUPTI_ACTIVITY_KIND_KERNEL
-- CUPTI_ACTIVITY_KIND_MEMSET
-- CUPTI_ACTIVITY_KIND_MEMCPY
-- NVTX_EVENTS
-
-Times are in nanoseconds
-"""
 
 
 class NSightSQLiteReader:
     # Dictionary mapping trace type
     # (e.g. NVTX,
     _trace_queries = {
-        # TODO: this is untested, find an application with nvtx
-        # support
-        # also likely broken from recent changes to this reader
-        # "nvtx": ["""
-        # SELECT
-        #     start as Enter,
-        #     end as Leave,
-        #     'annotation' as type,
-        #     rname.value AS Name,
-        #     (ne.globalTid >> 24) & 0x00FFFFFF AS "Process",
-        #     ne.globalTid & 0x00FFFFFF AS "Thread"
-        # FROM
-        #     NVTX_EVENTS as ne
-        # JOIN ThreadNames AS tname
-        #     ON ne.globalTid == tname.globalTid
-        # JOIN
-        #     StringIds AS rname
-        #     ON ne.textId = rname.id
-        # JOIN
-        #     StringIds AS rname2
-        #     ON tname.nameId = rname2.id
-        # """],
         "nvtx": [
             """
         SELECT

--- a/pipit/readers/nsight_sqlite_reader.py
+++ b/pipit/readers/nsight_sqlite_reader.py
@@ -2,7 +2,6 @@ import numpy as np
 import pandas as pd
 
 import pipit.trace
-from pipit.graph import Graph, Node
 import sqlite3
 
 """Need to read from the following tables:

--- a/pipit/trace.py
+++ b/pipit/trace.py
@@ -14,11 +14,13 @@ class Trace:
     includes one or more dataframes and a calling context tree.
     """
 
-    def __init__(self, definitions, events, cct=None):
+    # TODO: default should be empty list for parallelism levels, we should update other readers
+    def __init__(self, definitions, events, cct=None, parallelism_levels=["Process"]):
         """Create a new Trace object."""
         self.definitions = definitions
         self.events = events
         self.cct = cct
+        self.parallelism_levels = parallelism_levels
 
         # list of numeric columns which we can calculate inc/exc metrics with
         self.numeric_cols = list(
@@ -65,6 +67,14 @@ class Trace:
         from .readers.nsight_reader import NsightReader
 
         return NsightReader(filename, create_cct).read()
+
+    @staticmethod
+    def from_nsight_sqlite(filename, create_cct=False, trace_types="all"):
+        """Read an Nsight trace into a new Trace object."""
+        # import this lazily to avoid circular dependencies
+        from .readers.nsight_sqlite_reader import NSightSQLiteReader
+
+        return NSightSQLiteReader(filename, create_cct, trace_types).read()
 
     @staticmethod
     def from_csv(filename):
@@ -447,6 +457,7 @@ class Trace:
         """Generates histogram of message frequency by size."""
 
         # Filter by send events
+        # TODO: replace with str.match
         messages = self.events[self.events["Name"].isin(["MpiSend", "MpiIsend"])]
 
         # Get message sizes
@@ -540,13 +551,13 @@ class Trace:
         if per_process:
             return (
                 self.events.loc[self.events["Event Type"] == "Enter"]
-                .groupby([groupby_column, "Process"], observed=True)[metrics]
+                .groupby([groupby_column] + self.parallelism_levels, observed=True)[metrics]
                 .sum()
             )
         else:
             return (
                 self.events.loc[self.events["Event Type"] == "Enter"]
-                .groupby([groupby_column, "Process"], observed=True)[metrics]
+                .groupby([groupby_column] + self.parallelism_levels, observed=True)[metrics]
                 .sum()
                 .groupby(groupby_column)
                 .mean()
@@ -561,7 +572,7 @@ class Trace:
 
         Returns:
         A Pandas DataFrame indexed by function name that will have two columns:
-        one containing the imabalance which (max / mean) time for all ranks
+        one containing the imbalance which (max / mean) time for all ranks
         and the other containing a list of num_processes ranks with the highest
         imbalances
         """
@@ -585,14 +596,10 @@ class Trace:
         for function in functions:
             curr_series = flat_profile.loc[function]
 
-            top_n = curr_series.sort_values(by=metric, ascending=False).iloc[
-                0:num_display
-            ]
+            top_n = curr_series.sort_values(ascending=False).iloc[0:num_display]
 
-            imbalance_dict[mean_metric].append(curr_series.mean().values[0])
-            imbalance_dict[imb_metric].append(
-                (top_n.values[0] / curr_series.mean()).values[0]
-            )
+            imbalance_dict[mean_metric].append(curr_series.mean())
+            imbalance_dict[imb_metric].append(top_n.values[0] / curr_series.mean())
             imbalance_dict[imb_ranks].append(list(top_n.index))
 
         imbalance_df = pd.DataFrame(imbalance_dict)

--- a/pipit/trace.py
+++ b/pipit/trace.py
@@ -14,7 +14,8 @@ class Trace:
     includes one or more dataframes and a calling context tree.
     """
 
-    # TODO: default should be empty list for parallelism levels, we should update other readers
+    # TODO: default should be empty list for parallelism levels,
+    # we should update other readers
     def __init__(self, definitions, events, cct=None, parallelism_levels=["Process"]):
         """Create a new Trace object."""
         self.definitions = definitions

--- a/pipit/trace.py
+++ b/pipit/trace.py
@@ -551,13 +551,17 @@ class Trace:
         if per_process:
             return (
                 self.events.loc[self.events["Event Type"] == "Enter"]
-                .groupby([groupby_column] + self.parallelism_levels, observed=True)[metrics]
+                .groupby([groupby_column] + self.parallelism_levels, observed=True)[
+                    metrics
+                ]
                 .sum()
             )
         else:
             return (
                 self.events.loc[self.events["Event Type"] == "Enter"]
-                .groupby([groupby_column] + self.parallelism_levels, observed=True)[metrics]
+                .groupby([groupby_column] + self.parallelism_levels, observed=True)[
+                    metrics
+                ]
                 .sum()
                 .groupby(groupby_column)
                 .mean()

--- a/pipit/trace.py
+++ b/pipit/trace.py
@@ -14,14 +14,16 @@ class Trace:
     includes one or more dataframes and a calling context tree.
     """
 
-    # TODO: default should be empty list for parallelism levels,
-    # we should update other readers
-    def __init__(self, definitions, events, cct=None, parallelism_levels=["Process"]):
+    def __init__(self, definitions, events, cct=None, parallelism_levels=None):
         """Create a new Trace object."""
         self.definitions = definitions
         self.events = events
         self.cct = cct
-        self.parallelism_levels = parallelism_levels
+        if parallelism_levels is None:
+            self.parallelism_levels = ["Process"]
+        else:
+            assert isinstance(parallelism_levels, list)
+            self.parallelism_levels = parallelism_levels
 
         # list of numeric columns which we can calculate inc/exc metrics with
         self.numeric_cols = list(


### PR DESCRIPTION
TODO: 
- Formalize method for handling multiple "traces" in pipit
   - Nsight Systems contains many traces, interesting ones are
      - NVTX events
      - CUDA API trace (all cuda functions called)
      - Memory operations/Kernel Launches
- CPU/GPU Metrics
   - Some particularly interesting ones of note:
      - CPU Utilization/GPU utilization/Unified memory page faults, etc.
- Device Metadata
   - e.g. Might be interesting to attach metadata, such as GPU Name, GPU VRAM, # of SMs, etc. to the pipit Trace object (not on dataframe since not all dataframes can handle metadata)
   - Then we might be able to analyze perf across different types of GPUs (e.g. to figure out which GPU is right for which workload).
- Multi-device?
- Tests

cc @jhdavis8 since you were interested in the Nsight reader too

also cc @ocnkr since this is based off your previous PR.