### PR TITLE
fix indexing and update pandas code per v3.0 changes

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v2
@@ -31,19 +31,19 @@ jobs:
           pip install --upgrade numpy pandas pytest otf2
 
       - name: Lint and format check with flake8 and black
-        if: ${{ matrix.python-version == 3.9 }}
+        if: ${{ matrix.python-version == 3.14 }}
         run: |
           pip install --upgrade black flake8
           black --diff --check .
           flake8
 
       - name: Update coverage
-        if: ${{ matrix.python-version == 3.12 }}
+        if: ${{ matrix.python-version == 3.14 }}
         run: |
           pip install --upgrade coverage
 
       - name: Run coverage 
-        if: ${{ matrix.python-version == 3.12 }}
+        if: ${{ matrix.python-version == 3.14 }}
         run: |
           PYTHONPATH=. coverage run $(which pytest)
 
@@ -52,7 +52,7 @@ jobs:
           PYTHONPATH=. $(which pytest)
 
       - name: Upload coverage to Codecov
-        if: ${{ matrix.python-version == 3.12 }}
+        if: ${{ matrix.python-version == 3.14 }}
         uses: codecov/codecov-action@v4
         env:
           CODECOV_TOKEN: ${{ secrets.PIPIT_CODECOV_TOKEN }}
@@ -68,7 +68,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v2

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,6 @@ from pygments.token import Generic
 
 import pkg_resources
 
-
 # -- Project information -----------------------------------------------------
 
 project = "pipit"

--- a/docs/examples/csv_reader.py
+++ b/docs/examples/csv_reader.py
@@ -2,7 +2,6 @@
 
 import pipit as pp
 
-
 if __name__ == "__main__":
     # Use pipit's ``from_csv`` API to read in traces in CSV format.
     # The result is stored into pipit's Trace data structure.

--- a/docs/examples/hpctoolkit.py
+++ b/docs/examples/hpctoolkit.py
@@ -2,7 +2,6 @@
 
 import pipit as pp
 
-
 if __name__ == "__main__":
     # Path to HPCToolkit traces
     dirname = "../../pipit/tests/data/ping-pong-hpctoolkit"

--- a/docs/examples/nsight.py
+++ b/docs/examples/nsight.py
@@ -2,7 +2,6 @@
 
 import pipit as pp
 
-
 if __name__ == "__main__":
     # Path to Nsight traces
     filename = "../../pipit/tests/data/nbody-nvtx/trace.csv"

--- a/docs/examples/otf2_read.py
+++ b/docs/examples/otf2_read.py
@@ -2,7 +2,6 @@
 
 import pipit as pp
 
-
 if __name__ == "__main__":
     # Path to OTF2 traces
     dirname = "../../pipit/tests/data/ping-pong-otf2"

--- a/docs/examples/projections.py
+++ b/docs/examples/projections.py
@@ -2,7 +2,6 @@
 
 import pipit as pp
 
-
 if __name__ == "__main__":
     # Path to OTF2 traces
     dirname = "../../pipit/tests/data/ping-pong-projections"

--- a/pipit/trace.py
+++ b/pipit/trace.py
@@ -277,13 +277,18 @@ class Trace:
             enter_leave_df = self.events.loc[enter_leave_mask]
 
             # add dummy values for depth/parent/children
-            # (otherwise loc won't insert the values)
             self.events["_depth"] = 0
             self.events["_parent"] = None
             self.events["_children"] = None
-            self.events.loc[enter_leave_mask] = enter_leave_df.groupby(
-                self.parallelism_levels, group_keys=False, dropna=False
+
+            dummy = enter_leave_df.groupby(
+                self.parallelism_levels, group_keys=False, dropna=False, observed=False
             ).apply(_match_caller_callee_by_level)
+
+            # ensure proper indexing alignment on insert
+            self.events.loc[enter_leave_mask, "_depth"] = dummy["_depth"]
+            self.events.loc[enter_leave_mask, "_parent"] = dummy["_parent"]
+            self.events.loc[enter_leave_mask, "_children"] = dummy["_children"]
 
         self.events = self.events.astype({"_depth": "Int32", "_parent": "Int32"})
         self.events = self.events.astype({"_depth": "category", "_parent": "category"})
@@ -638,7 +643,7 @@ class Trace:
             return idle_time
 
         return (
-            self.events.groupby(self.parallelism_levels, dropna=False)
+            self.events.groupby(self.parallelism_levels, dropna=False, observed=False)
             .apply(
                 calc_idle_time,
             )
@@ -683,7 +688,7 @@ class Trace:
         self.calc_inc_metrics(["Timestamp (ns)"])
 
         # Filter by Enter rows
-        events = self.events[self.events["Event Type"] == "Enter"].copy(deep=False)
+        events = self.events[self.events["Event Type"] == "Enter"]
         names = events["Name"].unique().tolist()
 
         # Create equal-sized bins
@@ -706,7 +711,7 @@ class Trace:
             }
 
             # start out with exc times being a copy of inc times
-            exc_times = list(events["inc_time_in_bin"].copy(deep=False))
+            exc_times = list(events["inc_time_in_bin"])
 
             # filter to events that have children
             filtered_df = events.loc[events["_children"].notnull()]
@@ -741,7 +746,7 @@ class Trace:
             in_bin = events[
                 (events["_matching_timestamp"] > start)
                 & (events["Timestamp (ns)"] < end)
-            ].copy(deep=False)
+            ]
 
             # Calculate inc_time_in_bin for each function
             # Case 1 - Function starts in bin
@@ -776,7 +781,7 @@ class Trace:
             calc_exc_time_in_bin(in_bin)
 
             # Sum across all processes
-            agg = in_bin.groupby("Name")["exc_time_in_bin"].sum()
+            agg = in_bin.groupby("Name", observed=False)["exc_time_in_bin"].sum()
             profile.append(agg.to_dict())
 
         # Convert to DataFrame


### PR DESCRIPTION
This PR fixes breaking changes from Pandas 3.0.0:
* Default of `df.groupby(..., observed=False)` changed to `df.groupby(..., observed=True)`
* Copy-on-Write is now default
   * This deprecates the need for defensive copies
   * Also disallows chained assignment
* Changes to indexing assignment or `apply()` seemed to break lines 284 and 285

Note: Pandas 3.0.0 now has Python minimum version >= 3.11

Resolves: Issue https://github.com/hpcgroup/pipit/issues/153